### PR TITLE
Revert "space_usage_and_scroll"

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -14,9 +14,8 @@ $layout-break: "(min-width: #{$column-width + $grace-space})";
 
 @media #{$layout-break} {
   body {
-    // width: $column-width;
+    width: $column-width;
     margin: 40px auto;
-    padding: 40px;
   }
 
   p {
@@ -47,9 +46,7 @@ pre {
   background: $lighter;
   padding: 1em;
   overflow-x: auto;
-  word-break: break-word;
-  overflow-wrap: anywhere;
-  white-space: normal;
+  white-space: pre-wrap;
 
   code {
     padding: 0;
@@ -279,6 +276,7 @@ h1 {
   overflow-wrap: anywhere;
   white-space: normal;
   background: $marked;
+  max-width: 78%;
 
 }
 


### PR DESCRIPTION
Reverts WADComs/WADComs.github.io#39 Just as the spacing broke the layout of the top part of the site and took the full screen instead of just slightly spacing out more