### PR TITLE
fix: add missing YAML document delimiter to render command and references fields correctly

### DIFF
--- a/_wadcoms/PwshADmodule-Initial-Enum.md
+++ b/_wadcoms/PwshADmodule-Initial-Enum.md
@@ -28,3 +28,4 @@ attack_types:
 references:
   - https://docs.microsoft.com/en-us/powershell/module/activedirectory/
   - https://github.com/samratashok/ADModule
+---

--- a/_wadcoms/Rubeus-s4u.md
+++ b/_wadcoms/Rubeus-s4u.md
@@ -34,3 +34,4 @@ references:
   - https://github.com/GhostPack/Rubeus
   - https://viperone.gitbook.io/pentest-everything/everything/everything-active-directory/credential-access/steal-or-forge-kerberos-tickets/constrained-delegation
   - https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/abusing-kerberos-constrained-delegation
+---


### PR DESCRIPTION
Added `---` at the end of the file to correctly terminate the YAML frontmatter block.
This minor syntax fix ensures proper rendering and data extraction for the command and references blocks on the website.

![emptyfield2](https://github.com/user-attachments/assets/08668669-7912-46a1-8d59-dfa094297553)
![empty field](https://github.com/user-attachments/assets/4a1cb225-de79-43ab-a863-e4f303ad24a2)
