### PR TITLE
fix typo in SharpHound LDAP command

### DIFF
--- a/_wadcoms/SharpHound-LDAP.md
+++ b/_wadcoms/SharpHound-LDAP.md
@@ -11,7 +11,7 @@ description: |
   	Output File: output.zip
 
 command: |
-  SharpHound.exe --CollectionMethod All --LdapUsername john --LdapPassword password123 --ZipFileName output.zip
+  SharpHound.exe --CollectionMethods All --LdapUsername john --LdapPassword password123 --ZipFileName output.zip
 items:
   - Shell
   - Username


### PR DESCRIPTION
Fixes #57 - the --CollectionMethod flag should be --CollectionMethods (plural) per the current SharpHound CE docs.