### PR TITLE
Add Sift scanning commands

### DIFF
--- a/_wadcoms/Sift-Local.md
+++ b/_wadcoms/Sift-Local.md
@@ -1,0 +1,21 @@
+---
+description: |
+  Sift finds credentials, secrets and sensitive files on local filesystems. This command scans the C: drive and writes the findings to a log.
+
+  Command Reference:
+
+    Path: C:\
+
+    Output File: sift-findings.log
+
+command: |
+  .\sift.exe local --path C:\ --output sift-findings.log
+items:
+  - Shell
+OS:
+  - Windows
+attack_types:
+  - Enumeration
+references:
+  - https://github.com/Stratus-Security/Sift
+---

--- a/_wadcoms/Sift-Network-Creds.md
+++ b/_wadcoms/Sift-Network-Creds.md
@@ -1,0 +1,28 @@
+---
+description: |
+  Sift can scan SMB hosts without Active Directory discovery. This command scans a subnet using domain credentials.
+
+  Command Reference:
+
+    Target Subnet: 10.10.10.0/24
+
+    Domain: test.local
+
+    Username: john
+
+    Password: password123
+
+command: |
+  .\sift.exe network --subnet 10.10.10.0/24 --username john --password password123 --domain test.local --output sift-findings.log
+items:
+  - Username
+  - Password
+services:
+  - SMB
+OS:
+  - Windows
+attack_types:
+  - Enumeration
+references:
+  - https://github.com/Stratus-Security/Sift
+---

--- a/_wadcoms/Sift-Network-PTH.md
+++ b/_wadcoms/Sift-Network-PTH.md
@@ -1,0 +1,29 @@
+---
+description: |
+  Sift supports NTLMv2 pass-the-hash for targeted SMB scans. This command scans one Windows host using a username and NT hash.
+
+  Command Reference:
+
+    Target IP: 10.10.10.1
+
+    Domain: test.local
+
+    Username: john
+
+    Hash: 5fbc3d5fec8206a30f4b6c473d68ae76
+
+command: |
+  .\sift.exe network --device 10.10.10.1 --username john --nt-hash 5fbc3d5fec8206a30f4b6c473d68ae76 --domain test.local --output sift-findings.log
+items:
+  - Username
+  - Hash
+services:
+  - SMB
+  - NTLM
+OS:
+  - Windows
+attack_types:
+  - Enumeration
+references:
+  - https://github.com/Stratus-Security/Sift
+---

--- a/_wadcoms/Sift.md
+++ b/_wadcoms/Sift.md
@@ -1,0 +1,29 @@
+---
+description: |
+  Sift finds credentials, secrets and sensitive files on accessible SMB shares. This command discovers domain computers over LDAP and scans their shares using the supplied account.
+
+  Command Reference:
+
+    Domain: test.local
+
+    Domain Controller: 10.10.10.1
+
+    Username: john
+
+    Password: password123
+
+command: |
+  .\sift.exe domain --username john --password password123 --domain test.local --domain-controller 10.10.10.1 --output sift-findings.log
+items:
+  - Username
+  - Password
+services:
+  - SMB
+  - LDAP
+OS:
+  - Windows
+attack_types:
+  - Enumeration
+references:
+  - https://github.com/Stratus-Security/Sift
+---


### PR DESCRIPTION
Adds four Sift examples: a local filesystem scan, an LDAP-discovered domain scan, a credentialed subnet scan, and a targeted pass-the-hash scan.

The commands use the standard WADComs sample values and existing filters.